### PR TITLE
Implement forget feature

### DIFF
--- a/ai_user/ai_user.py
+++ b/ai_user/ai_user.py
@@ -34,6 +34,7 @@ class AI_User(Settings, commands.Cog, metaclass=CompositeMetaClass):
             "model": "gpt-3.5-turbo",
             "custom_text_prompt": None,
             "channels_whitelist": [],
+            "public_forget": False,
         }
 
         default_member = {

--- a/ai_user/ai_user.py
+++ b/ai_user/ai_user.py
@@ -1,29 +1,28 @@
 
 import logging
 import random
-from datetime import datetime, timezone
-
 import discord
 import openai
+from datetime import datetime, timezone
 from redbot.core import Config, app_commands, commands
 from redbot.core.bot import Red
 
 from ai_user.abc import CompositeMetaClass
 from ai_user.prompts.prompt_factory import create_prompt_instance
-from ai_user.prompts.text_prompt import MAX_MESSAGE_LENGTH, MIN_MESSAGE_LENGTH
+from ai_user.prompts.constants import MIN_MESSAGE_LENGTH, MAX_MESSAGE_LENGTH
 from ai_user.response.response import generate_response
-from ai_user.settings import settings
+from ai_user.settings import Settings
 
 logger = logging.getLogger("red.bz_cogs.ai_user")
 
 
-class AI_User(settings, commands.Cog, metaclass=CompositeMetaClass):
-
+class AI_User(Settings, commands.Cog, metaclass=CompositeMetaClass):
     def __init__(self, bot):
         super().__init__()
         self.bot: Red = bot
         self.config = Config.get_conf(self, identifier=754070)
         self.cached_options = {}
+        self.override_prompt_start_time = {}
 
         default_guild = {
             "reply_percent": 0.5,
@@ -56,7 +55,8 @@ class AI_User(settings, commands.Cog, metaclass=CompositeMetaClass):
         if not await self.is_common_valid_reply(ctx):
             return
 
-        prompt_instance = await create_prompt_instance(ctx.message, self.config)
+        start_time = self.override_prompt_start_time.get(ctx.guild.id, None)
+        prompt_instance = await create_prompt_instance(ctx.message, self.config, start_time)
         prompt = await prompt_instance.get_prompt()
         if prompt is None:
             return await ctx.send("Error: No prompt set.", ephemeral=True)
@@ -80,7 +80,8 @@ class AI_User(settings, commands.Cog, metaclass=CompositeMetaClass):
         elif random.random() > self.cached_options[message.guild.id].get("reply_percent"):
             return
 
-        prompt_instance = await create_prompt_instance(message, self.config)
+        start_time = self.override_prompt_start_time.get(ctx.guild.id, None)
+        prompt_instance = await create_prompt_instance(message, self.config, start_time)
         prompt = await prompt_instance.get_prompt()
         if prompt is None:
             return
@@ -104,7 +105,8 @@ class AI_User(settings, commands.Cog, metaclass=CompositeMetaClass):
 
         prompt = None
         if len(before.embeds) != len(after.embeds):
-            prompt_instance = await create_prompt_instance(after, self.config)
+            start_time = self.override_prompt_start_time.get(before.guild.id, None)
+            prompt_instance = await create_prompt_instance(after, self.config, start_time)
             prompt = await prompt_instance.get_prompt()
         if prompt is None:
             return
@@ -129,7 +131,7 @@ class AI_User(settings, commands.Cog, metaclass=CompositeMetaClass):
             return False
 
         if not self.cached_options.get(ctx.message.guild.id):
-            await self.cache_guild_options(ctx.message)
+            await self.cache_guild_options(ctx)
 
         if isinstance(ctx.channel, discord.Thread):
             if ctx.channel.parent.id not in self.cached_options[ctx.guild.id].get("channels_whitelist"):

--- a/ai_user/prompts/constants.py
+++ b/ai_user/prompts/constants.py
@@ -4,3 +4,5 @@ PRESETS = {
     "neutral": "You are in a Discord text channel. Respond to anything, including URLs.  Do not react to username before \"said:\". Do not include \"said:\" or \":\" in your response.",
     "tsundere": "You are in a Discord text channel. Pretend you are a tsundere girl when responding. Use text emojis. Do not let people know you are a chatbot or bot.  Do not react to username before \"said:\". Do not include \"said:\" or \":\" in your response.",
 }
+MIN_MESSAGE_LENGTH = 5
+MAX_MESSAGE_LENGTH = 300

--- a/ai_user/prompts/embed_prompt.py
+++ b/ai_user/prompts/embed_prompt.py
@@ -10,10 +10,10 @@ logger = logging.getLogger("red.bz_cogs.ai_user")
 
 
 class EmbedPrompt(Prompt):
-    def __init__(self, message: Message, config):
-        super().__init__(message, config)
+    def __init__(self, message: Message, config, start_time):
+        super().__init__(message, config, start_time)
 
-    async def _create_prompt(self, bot_prompt) -> Optional[str]:
+    async def _create_prompt(self, bot_prompt) -> Optional[list[dict[str, str]]]:
         if len(self.message.embeds) == 0 or not self.message.embeds[0].title or not self.message.embeds[0].description:
             logger.debug(
                 f"Skipping unloaded embed in {self.message.guild.name}")

--- a/ai_user/prompts/image_prompt.py
+++ b/ai_user/prompts/image_prompt.py
@@ -22,10 +22,10 @@ def to_thread(func: Callable) -> Coroutine:
 
 
 class ImagePrompt(Prompt):
-    def init(self, message: Message, config):
-        super().init(message, config)
+    def __init__(self, message: Message, config, start_time):
+        super().__init__(message, config, start_time)
 
-    async def _create_prompt(self, bot_prompt) -> Optional[str]:
+    async def _create_prompt(self, bot_prompt) -> Optional[list[dict[str, str]]]:
         image = self.message.attachments[0] if self.message.attachments else None
 
         if not image or not image.content_type.startswith('image/'):
@@ -39,14 +39,14 @@ class ImagePrompt(Prompt):
             return None
 
         prompt = None
-        scanned_text = await ImagePrompt._extract_text_from_image(image)
+        scanned_text = await self._extract_text_from_image(image)
         if scanned_text and len(scanned_text.split()) > 10:
             prompt = [
                 {"role": "system", "content": f"The following text is from a picture sent by user \"{self.message.author.name}\". {bot_prompt}"},
                 {"role": "user", "content": scanned_text},
             ]
         else:
-            confidence, caption = await ImagePrompt._create_prompt_from_image(image)
+            confidence, caption = await self._create_prompt_from_image(image)
             if confidence > 0.45:
                 prompt = [
                     {"role": "system", "content": f"The following is a description of a picture sent by user \"{self.message.author.name}\". {bot_prompt}"},

--- a/ai_user/prompts/prompt_factory.py
+++ b/ai_user/prompts/prompt_factory.py
@@ -1,5 +1,8 @@
 import logging
 import re
+from datetime import datetime
+from discord import Message
+from redbot.core import Config
 
 from ai_user.prompts.embed_prompt import EmbedPrompt
 from ai_user.prompts.text_prompt import TextPrompt
@@ -7,19 +10,19 @@ from ai_user.prompts.text_prompt import TextPrompt
 logger = logging.getLogger("red.bz_cogs.ai_user")
 
 
-async def create_prompt_instance(message, config):
+async def create_prompt_instance(message: Message, config: Config, start_time: datetime):
     url_pattern = re.compile(r"(https?://\S+)")
     contains_url = url_pattern.search(message.content)
     if message.attachments and await config.guild(message.guild).scan_images():
         try:
             from ai_user.prompts.image_prompt import ImagePrompt
-            return ImagePrompt(message, config)
+            return ImagePrompt(message, config, start_time)
         except ImportError:
             logger.error(
                 f"Unable load image scanning dependencies, disabling image scanning for this server f{message.guild.name}...")
             await config.guild(message.guild).scan_images.set(False)
             raise
     elif contains_url:
-        return EmbedPrompt(message, config)
+        return EmbedPrompt(message, config, start_time)
     else:
-        return TextPrompt(message, config)
+        return TextPrompt(message, config, start_time)

--- a/ai_user/prompts/text_prompt.py
+++ b/ai_user/prompts/text_prompt.py
@@ -2,17 +2,17 @@ import logging
 from typing import Optional
 from discord import Message
 from ai_user.prompts.base import Prompt
+from ai_user.prompts.constants import MIN_MESSAGE_LENGTH, MAX_MESSAGE_LENGTH
 
 logger = logging.getLogger("red.bz_cogs.ai_user")
 
-MIN_MESSAGE_LENGTH = 5
-MAX_MESSAGE_LENGTH = 300
 
 class TextPrompt(Prompt):
-    def __init__(self, message: Message, config):
-        super().__init__(message, config)
+    def __init__(self, message: Message, config, start_time):
+        super().__init__(message, config, start_time)
 
-    def _is_acceptable_message(self, message: Message) -> bool:
+    @staticmethod
+    def _is_acceptable_message(message: Message) -> bool:
         if not message.content:
             logger.debug(f"Skipping empty message in {message.guild.name}")
             return False
@@ -29,7 +29,7 @@ class TextPrompt(Prompt):
 
         return True
 
-    async def _create_prompt(self, bot_prompt) -> Optional[str]:
+    async def _create_prompt(self, bot_prompt) -> Optional[list[dict[str, str]]]:
         if not self._is_acceptable_message(self.message):
             return None
 

--- a/ai_user/settings.py
+++ b/ai_user/settings.py
@@ -1,9 +1,8 @@
 import importlib
 import logging
-from typing import Optional
-
 import discord
 import openai
+from typing import Optional
 from redbot.core import checks, commands
 from redbot.core.utils.chat_formatting import box
 from redbot.core.utils.menus import DEFAULT_CONTROLS, menu
@@ -14,28 +13,34 @@ from ai_user.prompts.constants import DEFAULT_PROMPT, PRESETS
 logger = logging.getLogger("red.bz_cogs.ai_user")
 
 
-class settings(MixinMeta):
+class Settings(MixinMeta):
     @commands.group()
     async def ai_user(self, _):
         pass
 
     @ai_user.command()
-    async def config(self, message):
+    async def forget(self, ctx: commands.Context):
+        """ Forces the AI to forget the current conversation up to this point. """
+        self.override_prompt_start_time[ctx.guild.id] = ctx.message.created_at
+        await ctx.react_quietly("✅")
+
+    @ai_user.command()
+    async def config(self, ctx: commands.Context):
         """ Returns current config """
-        whitelist = await self.config.guild(message.guild).channels_whitelist()
+        whitelist = await self.config.guild(ctx.guild).channels_whitelist()
         channels = [f"<#{channel_id}>" for channel_id in whitelist]
 
         embed = discord.Embed(title="AI User Settings")
-        embed.add_field(name="Scan Images", value=await self.config.guild(message.guild).scan_images(), inline=False)
-        embed.add_field(name="Model", value=await self.config.guild(message.guild).model(), inline=False)
-        embed.add_field(name="Filter Responses", value=await self.config.guild(message.guild).filter_responses(), inline=False)
-        embed.add_field(name="Reply Percent", value=f"{await self.config.guild(message.guild).reply_percent() * 100}%", inline=False)
+        embed.add_field(name="Scan Images", value=await self.config.guild(ctx.guild).scan_images(), inline=False)
+        embed.add_field(name="Model", value=await self.config.guild(ctx.guild).model(), inline=False)
+        embed.add_field(name="Filter Responses", value=await self.config.guild(ctx.guild).filter_responses(), inline=False)
+        embed.add_field(name="Reply Percent", value=f"{await self.config.guild(ctx.guild).reply_percent() * 100}%", inline=False)
         embed.add_field(name="Whitelisted Channels", value=" ".join(channels)\
                         if channels else "None", inline=False)
-        embed.add_field(name="Always Reply on Ping or Reply", value=await self.config.guild(message.guild).reply_to_mentions_replies(), inline=False)
-        embed.add_field(name="Max Messages in History", value=f"{await self.config.guild(message.guild).messages_backread()}", inline=False)
-        embed.add_field(name="Max Time (s) between each Message in History", value=f"{await self.config.guild(message.guild).messages_backread_seconds()}", inline=False)
-        return await message.send(embed=embed)
+        embed.add_field(name="Always Reply on Ping or Reply", value=await self.config.guild(ctx.guild).reply_to_mentions_replies(), inline=False)
+        embed.add_field(name="Max Messages in History", value=f"{await self.config.guild(ctx.guild).messages_backread()}", inline=False)
+        embed.add_field(name="Max Time (s) between each Message in History", value=f"{await self.config.guild(ctx.guild).messages_backread_seconds()}", inline=False)
+        return await ctx.send(embed=embed)
 
     @ai_user.command()
     @checks.is_owner()
@@ -180,6 +185,7 @@ class settings(MixinMeta):
     @checks.is_owner()
     async def reset(self, ctx: commands.Context):
         """ Reset ALL prompts (inc. user) to default (cynical)"""
+        self.override_prompt_start_time[ctx.guild.id] = ctx.message.created_at
         await self.config.guild(ctx.guild).custom_text_prompt.set(None)
         for member in ctx.guild.members:
             await self.config.member(member).custom_text_prompt.set(None)
@@ -247,6 +253,7 @@ class settings(MixinMeta):
     @checks.is_owner()
     async def server(self, ctx: commands.Context, *, prompt: Optional[str]):
         """ Set custom prompt for current server """
+        self.override_prompt_start_time[ctx.guild.id] = ctx.message.created_at
         if not prompt:
             await self.config.guild(ctx.guild).custom_text_prompt.set(None)
             return await ctx.send(f"The prompt for this server is now reset to the default prompt")
@@ -267,11 +274,12 @@ class settings(MixinMeta):
         res += box(f"{self._truncate_prompt(prompt)}")
         return await ctx.send(res)
 
-    async def cache_guild_options(self, message: discord.Message):
-        self.cached_options[message.guild.id] = {
-            "channels_whitelist": await self.config.guild(message.guild).channels_whitelist(),
-            "reply_percent": await self.config.guild(message.guild).reply_percent(),
+    async def cache_guild_options(self, ctx: commands.Context):
+        self.cached_options[ctx.guild.id] = {
+            "channels_whitelist": await self.config.guild(ctx.guild).channels_whitelist(),
+            "reply_percent": await self.config.guild(ctx.guild).reply_percent(),
         }
 
-    def _truncate_prompt(self, prompt: str) -> str:
+    @staticmethod
+    def _truncate_prompt(prompt: str) -> str:
         return prompt[:1900] + "..." if len(prompt) > 1900 else prompt


### PR DESCRIPTION
It will ignore messages before `{current timestamp - 1 second}` whenever the `[p]ai_user forget` command is used, and whenever the server prompt changes.

Who can use `[p]ai_user forget` is determined by a new `public_forget` setting, when `True` anyone can use it, when `False` only people with the `manage_messages` permission can use it.