### PR TITLE
Add ignore by regex feature

### DIFF
--- a/ai_user/prompts/base.py
+++ b/ai_user/prompts/base.py
@@ -1,6 +1,5 @@
 from datetime import datetime, timedelta
 from typing import Dict, Optional
-
 from discord import Member, Message
 from redbot.core import Config
 
@@ -66,9 +65,9 @@ class Prompt:
 
         return history
 
-    async def _handle_historical_reply(self, history, message):
+    async def _handle_historical_reply(self, history: list, message: Message):
         try:
-            replied_message = await message.channel.fetch_message(message.reference.message_id)
+            replied_message = message.reference.cached_message or await message.channel.fetch_message(message.reference.message_id)
         except:
             return
         if self.is_not_valid_message(replied_message):

--- a/ai_user/response/processing.py
+++ b/ai_user/response/processing.py
@@ -4,7 +4,7 @@ def remove_template_from_response(response: str, bot_name: str) -> str:
     patterns = [
         rf'^(User )?"?{bot_name}"? (said|says|respond(ed|s)|replie[ds])( to [^":]+)?:?',
         rf'^As "?{bot_name}"?, (I|you)( might| would| could)? (respond|reply|say)( with)?( something like)?:?',
-        rf'^[<({{\[]{bot_name}[>)}}\]]'  # [name], {name}, <name>, (name)
+        rf'^[<({{\[]{bot_name}[>)}}\]]',  # [name], {name}, <name>, (name)
         rf'^{bot_name}:',
     ]
     response = response.strip(' "')

--- a/ai_user/response/processing.py
+++ b/ai_user/response/processing.py
@@ -4,6 +4,7 @@ def remove_template_from_response(response: str, bot_name: str) -> str:
     patterns = [
         rf'^(User )?"?{bot_name}"? (said|says|respond(ed|s)|replie[ds])( to [^":]+)?:?',
         rf'^As "?{bot_name}"?, (I|you)( might| would| could)? (respond|reply|say)( with)?( something like)?:?',
+        rf'^[<({{\[]{bot_name}[>)}}\]]'  # [name], {name}, <name>, (name)
         rf'^{bot_name}:',
     ]
     response = response.strip(' "')

--- a/ai_user/settings.py
+++ b/ai_user/settings.py
@@ -50,15 +50,15 @@ class Settings(MixinMeta):
                         value=await self.config.guild(ctx.guild).scan_images_mode())
         embed.add_field(name="Scan Image Max Size", inline=True,
                         value=f"{await self.config.guild(ctx.guild).max_image_size() / 1024 / 1024:.2f} MB")
-        embed.add_field(name="Max Messages in History", inline=True,
-                        value=f"{await self.config.guild(ctx.guild).messages_backread()}")
+        embed.add_field(name="Max History Size", inline=True,
+                        value=f"{await self.config.guild(ctx.guild).messages_backread()} messages")
+        embed.add_field(name="Max History Gap", inline=True,
+                        value=f"{await self.config.guild(ctx.guild).messages_backread_seconds()} seconds")
         embed.add_field(name="Always Reply if Pinged", inline=True,
                         value=await self.config.guild(ctx.guild).reply_to_mentions_replies())
         embed.add_field(name="Ignore Regex Pattern", inline=True,
                         value=await self.config.guild(ctx.guild).ignore_regex())
-        embed.add_field(name="Max Time (s) between each Message in History", inline=False,
-                        value=await self.config.guild(ctx.guild).messages_backread_seconds())
-        embed.add_field(name="Public Forget Command", inline=False,
+        embed.add_field(name="Public Forget Command", inline=True,
                         value=await self.config.guild(ctx.guild).public_forget())
         embed.add_field(name="Whitelisted Channels", inline=False,
                         value=" ".join(channels) if channels else "None")
@@ -259,9 +259,9 @@ class Settings(MixinMeta):
         """ Change the prompt context settings for the current server """
         pass
 
-    @history.command()
+    @history.command(name="backread", aliases=["messages", "size"])
     @checks.is_owner()
-    async def backread(self, ctx: commands.Context, new_value: int):
+    async def history_backread(self, ctx: commands.Context, new_value: int):
         """ Set max amount of messages to be used """
         await self.config.guild(ctx.guild).messages_backread.set(new_value)
         embed = discord.Embed(
@@ -270,9 +270,9 @@ class Settings(MixinMeta):
             color=await ctx.embed_color())
         return await ctx.send(embed=embed)
 
-    @history.command()
+    @history.command(name="time", aliases=["gap"])
     @checks.is_owner()
-    async def time(self, ctx: commands.Context, new_value: int):
+    async def history_time(self, ctx: commands.Context, new_value: int):
         """ Set max time (s) allowed between messages to be used """
         await self.config.guild(ctx.guild).messages_backread_seconds.set(new_value)
         embed = discord.Embed(

--- a/ai_user/settings.py
+++ b/ai_user/settings.py
@@ -206,7 +206,7 @@ class Settings(MixinMeta):
             return await ctx.send("Channel already in whitelist")
         new_whitelist.append(channel.id)
         await self.config.guild(ctx.guild).channels_whitelist.set(new_whitelist)
-        self.whitelisted_channels[ctx.guild.id] = new_whitelist
+        self.channels_whitelist[ctx.guild.id] = new_whitelist
         embed = discord.Embed(title="The server whitelist is now:", color=await ctx.embed_color())
         channels = [f"<#{channel_id}>" for channel_id in new_whitelist]
         embed.description = "\n".join(channels) if channels else "None"
@@ -223,7 +223,7 @@ class Settings(MixinMeta):
             return await ctx.send("Channel not in whitelist")
         new_whitelist.remove(channel.id)
         await self.config.guild(ctx.guild).channels_whitelist.set(new_whitelist)
-        self.whitelisted_channels[ctx.guild.id] = new_whitelist
+        self.channels_whitelist[ctx.guild.id] = new_whitelist
         embed = discord.Embed(title="The server whitelist is now:", color=await ctx.embed_color())
         channels = [f"<#{channel_id}>" for channel_id in new_whitelist]
         embed.description = "\n".join(channels) if channels else "None"

--- a/ai_user/settings.py
+++ b/ai_user/settings.py
@@ -50,16 +50,16 @@ class Settings(MixinMeta):
                         value=await self.config.guild(ctx.guild).scan_images_mode())
         embed.add_field(name="Scan Image Max Size", inline=True,
                         value=f"{await self.config.guild(ctx.guild).max_image_size() / 1024 / 1024:.2f} MB")
-        embed.add_field(name="Always Reply on Ping or Reply", inline=False,
-                        value=await self.config.guild(ctx.guild).reply_to_mentions_replies())
-        embed.add_field(name="Max Messages in History", inline=False,
+        embed.add_field(name="Max Messages in History", inline=True,
                         value=f"{await self.config.guild(ctx.guild).messages_backread()}")
+        embed.add_field(name="Always Reply if Pinged", inline=True,
+                        value=await self.config.guild(ctx.guild).reply_to_mentions_replies())
+        embed.add_field(name="Ignore Regex Pattern", inline=True,
+                        value=await self.config.guild(ctx.guild).ignore_regex())
         embed.add_field(name="Max Time (s) between each Message in History", inline=False,
                         value=await self.config.guild(ctx.guild).messages_backread_seconds())
         embed.add_field(name="Public Forget Command", inline=False,
                         value=await self.config.guild(ctx.guild).public_forget())
-        embed.add_field(name="Ignore Regex Pattern", inline=False,
-                        value=await self.config.guild(ctx.guild).ignore_regex())
         embed.add_field(name="Whitelisted Channels", inline=False,
                         value=" ".join(channels) if channels else "None")
         return await ctx.send(embed=embed)


### PR DESCRIPTION
Messages matching a configurable regex won't trigger an AI response. I wanted this feature as I realized that aliased commands still call `on_message_without_command`. A bonus is it lets me ignore prefixes of all my bots. It may also be used for moderation purposes, and who knows what else.

After the history code is rewritten, it could incorporate this setting to make those messages invisible to the bot.

Also reorders the message checks to make the async ones go last.

Also this is how the config looks now:

![image](https://user-images.githubusercontent.com/33796679/236937876-c4e09593-9576-4b11-b5d4-93d65b963ac1.png)
