### PR TITLE
Fixed issue with JSON parsing with 

### DIFF
--- a/aiuser/settings/response.py
+++ b/aiuser/settings/response.py
@@ -307,7 +307,7 @@ class ResponseSettings(MixinMeta):
 
         embed = discord.Embed(title="Custom Parameters", color=await ctx.embed_color())
         parameters = await self.config.guild(ctx.guild).parameters()
-        data = json.loads(parameters)
+        data = {} if parameters is None else json.loads(parameters)
 
         if json_block not in ['show', 'list']:
             if not json_block.startswith("```"):


### PR DESCRIPTION
Overview:
This PR addresses a bug where the system raised a TypeError when trying to load a JSON value that is null as NoneType. This occurred when using [p]aiuser response parameters. The change adds an exception if the data is null as it being null made it impossible to even touch or change this command.