### PR TITLE
New aimage settings: width, height, checkpoint, adetailer, auth

### DIFF
--- a/aimage/abc.py
+++ b/aimage/abc.py
@@ -1,7 +1,7 @@
 from abc import ABC
 
-from aiohttp import ClientSession
 import discord
+from aiohttp import ClientSession
 from redbot.core import Config, commands
 from redbot.core.bot import Red
 
@@ -20,6 +20,9 @@ class MixinMeta(ABC):
         pass
 
     async def _fetch_data(self, guild: discord.Guild, endpoint_suffix: str):
+        pass
+
+    async def get_auth(self, auth_str: str):
         pass
 
     async def generate_image(self, *args, **kwargs):

--- a/aimage/aimage.py
+++ b/aimage/aimage.py
@@ -33,6 +33,7 @@ class AImage(Settings,
 
         default_global = {
             "endpoint": None,
+            "auth": None,
             "nsfw": True,
             "words_blacklist": DEFAULT_BADWORDS_BLACKLIST
         }
@@ -45,6 +46,11 @@ class AImage(Settings,
             "cfg": 7,
             "sampling_steps": 20,
             "sampler": "Euler a",
+            "checkpoint": None,
+            "adetailer": False,
+            "width": 512,
+            "height": 512,
+            "auth": None,
         }
 
         self.session = aiohttp.ClientSession()
@@ -133,16 +139,19 @@ class AImage(Settings,
         interaction: discord.Interaction,
         prompt: str,
         negative_prompt: str = None,
+        width: app_commands.Range[int, 256, 768] = None,
+        height: app_commands.Range[int, 256, 768] = None,
         cfg: app_commands.Range[float, 1, 30] = None,
         steps: app_commands.Range[int, 1, 150] = None,
         sampler: str = None,
         seed: app_commands.Range[int, -1, None] = -1,
+        checkpoint: str = None,
         lora: str = None
     ):
         """
         Generate an image using Stable Diffusion
         """
-        await self.generate_image(interaction, prompt, lora, cfg, negative_prompt, steps, seed, sampler)
+        await self.generate_image(interaction, prompt, lora, cfg, negative_prompt, steps, seed, sampler, width, height, checkpoint)
         asyncio.create_task(self._update_autocomplete_cache(interaction))
 
     async def _update_autocomplete_cache(self, interaction: discord.Interaction):

--- a/aimage/constants.py
+++ b/aimage/constants.py
@@ -37,3 +37,48 @@ AUTO_COMPLETE_SAMPLERS = [
     "PLMS",
     "UniPC"
 ]
+
+ADETAILER_ARGS = {
+    "ADetailer": {
+        "args": [
+            True,
+            False,
+            {
+                "ad_model": "face_yolov8n.pt",
+                "ad_prompt": "",
+                "ad_negative_prompt": "",
+                "ad_confidence": 0.3,
+                "ad_mask_k_largest": 0,
+                "ad_mask_min_ratio": 0.0,
+                "ad_mask_max_ratio": 1.0,
+                "ad_dilate_erode": 32,
+                "ad_x_offset": 0,
+                "ad_y_offset": 0,
+                "ad_mask_merge_invert": "None",
+                "ad_mask_blur": 4,
+                "ad_denoising_strength": 0.4,
+                "ad_inpaint_only_masked": True,
+                "ad_inpaint_only_masked_padding": 0,
+                "ad_use_inpaint_width_height": False,
+                "ad_inpaint_width": 512,
+                "ad_inpaint_height": 512,
+                "ad_use_steps": True,
+                "ad_steps": 28,
+                "ad_use_cfg_scale": False,
+                "ad_cfg_scale": 7.0,
+                "ad_use_sampler": False,
+                "ad_sampler": "DPM++ 2M Karras",
+                "ad_use_noise_multiplier": False,
+                "ad_noise_multiplier": 1.0,
+                "ad_use_clip_skip": False,
+                "ad_clip_skip": 1,
+                "ad_restore_face": False,
+                "ad_controlnet_model": "None",
+                "ad_controlnet_module": "None",
+                "ad_controlnet_weight": 1.0,
+                "ad_controlnet_guidance_start": 0.0,
+                "ad_controlnet_guidance_end": 1.0
+            }
+        ]
+    }
+}

--- a/aimage/functions.py
+++ b/aimage/functions.py
@@ -1,17 +1,17 @@
 import base64
 import io
 import json
-import aiohttp
 import logging
 from typing import Union
 
+import aiohttp
 import discord
 from redbot.core import commands
 from tenacity import retry, stop_after_attempt, wait_random
 
 from aimage.abc import MixinMeta
-from aimage.views import ImageActions
 from aimage.constants import ADETAILER_ARGS
+from aimage.views import ImageActions
 
 logger = logging.getLogger("red.bz_cogs.aimage")
 
@@ -38,7 +38,7 @@ class Functions(MixinMeta):
 
         guild = context.guild
 
-        endpoint, auth, nsfw = await self._get_endpoint(guild)
+        endpoint, auth_str, nsfw = await self._get_endpoint(guild)
         if not endpoint:
             return await self.sent_response(context, content=":warning: Endpoint not yet set for this server!")
 
@@ -70,7 +70,7 @@ class Functions(MixinMeta):
             payload["script_args"] = [True, True]
 
         try:
-            image_data, info_string, is_nsfw = await self._post_sd_endpoint(endpoint, payload, auth)
+            image_data, info_string, is_nsfw = await self._post_sd_endpoint(endpoint, payload, auth_str)
         except:
             logger.exception("Failed request to Stable Diffusion endpoint")
             return await self.sent_response(context, content=":warning: Something went wrong!", ephemeral=True)
@@ -92,14 +92,14 @@ class Functions(MixinMeta):
         await context.send(**kwargs)
 
     async def _get_endpoint(self, guild: discord.Guild):
-        endpoint = await self.config.guild(guild).endpoint()
-        auth = await self.config.guild(guild).auth()
-        nsfw = await self.config.guild(guild).nsfw()
+        endpoint: str = await self.config.guild(guild).endpoint()
+        auth: str = await self.config.guild(guild).auth()
+        nsfw: bool = await self.config.guild(guild).nsfw()
         if not endpoint:
             endpoint = await self.config.endpoint()
             auth = await self.config.auth()
             nsfw = await self.config.nsfw() and nsfw
-        return endpoint, auth, nsfw
+        return (endpoint, auth, nsfw)
 
     async def _contains_blacklisted_word(self, guild: discord.Guild, prompt: str):
         endpoint = await self.config.guild(guild).endpoint()
@@ -115,10 +115,8 @@ class Functions(MixinMeta):
     @retry(wait=wait_random(min=2, max=5), stop=stop_after_attempt(2), reraise=True)
     async def _post_sd_endpoint(self, endpoint, payload, auth_str):
         url = endpoint + "txt2img"
-        if auth_str:
-            username, password = auth_str.split(':')
-            auth = aiohttp.BasicAuth(username, password)
-        async with self.session.post(url=url, json=payload, auth=auth) as response:
+
+        async with self.session.post(url=url, json=payload, auth=self.get_auth(auth_str)) as response:
             if response.status != 200:
                 response.raise_for_status()
             r = await response.json()
@@ -149,9 +147,10 @@ class Functions(MixinMeta):
     async def _fetch_data(self, guild: discord.Guild, endpoint_suffix: str):
         res = None
         try:
-            endpoint, _ = await self._get_endpoint(guild)
+            endpoint, auth_str, _ = await self._get_endpoint(guild)
             url = endpoint + endpoint_suffix
-            async with self.session.get(url) as response:
+
+            async with self.session.get(url, auth=self.get_auth(auth_str)) as response:
                 if response.status != 200:
                     response.raise_for_status()
                 res = await response.json()
@@ -160,3 +159,10 @@ class Functions(MixinMeta):
                 f"Failed getting {endpoint_suffix} from Stable Diffusion endpoint in server {guild.id}")
 
         return res
+
+    def get_auth(self, auth_str: str):
+        auth = None
+        if auth_str:
+            username, password = auth_str.split(':')
+            auth = aiohttp.BasicAuth(username, password)
+        return auth

--- a/aimage/functions.py
+++ b/aimage/functions.py
@@ -68,7 +68,7 @@ class Functions(MixinMeta):
             payload["script_args"] = [True, True]
 
         try:
-            image_data, info_string, is_nsfw = await self._post_sd_endpoint(endpoint, payload)
+            image_data, info_string, is_nsfw = await self._post_sd_endpoint(endpoint, payload, auth)
         except:
             logger.exception("Failed request to Stable Diffusion endpoint")
             return await self.sent_response(context, content=":warning: Something went wrong!", ephemeral=True)
@@ -111,10 +111,8 @@ class Functions(MixinMeta):
         return False
 
     @retry(wait=wait_random(min=2, max=5), stop=stop_after_attempt(2), reraise=True)
-    async def _post_sd_endpoint(self, endpoint, payload):
+    async def _post_sd_endpoint(self, endpoint, payload, auth_str):
         url = endpoint + "txt2img"
-        auth = None
-        auth_str = await self.config.auth()
         if auth_str:
             username, password = auth_str.split(':')
             auth = aiohttp.BasicAuth(username, password)

--- a/aimage/functions.py
+++ b/aimage/functions.py
@@ -1,6 +1,7 @@
 import base64
 import io
 import json
+import aiohttp
 import logging
 from typing import Union
 
@@ -10,6 +11,7 @@ from tenacity import retry, stop_after_attempt, wait_random
 
 from aimage.abc import MixinMeta
 from aimage.views import ImageActions
+from aimage.constants import ADETAILER_ARGS
 
 logger = logging.getLogger("red.bz_cogs.aimage")
 
@@ -24,6 +26,9 @@ class Functions(MixinMeta):
                              steps: int = None,
                              seed: int = -1,
                              sampler: str = None,
+                             width: int = None,
+                             height: int = None,
+                             checkpoint: str = None,
                              payload: dict = None):
 
         if isinstance(context, discord.Interaction):
@@ -33,7 +38,7 @@ class Functions(MixinMeta):
 
         guild = context.guild
 
-        endpoint, nsfw = await self._get_endpoint(guild)
+        endpoint, auth, nsfw = await self._get_endpoint(guild)
         if not endpoint:
             return await self.sent_response(context, content=":warning: Endpoint not yet set for this server!")
 
@@ -50,7 +55,13 @@ class Functions(MixinMeta):
             "steps": steps or await self.config.guild(guild).sampling_steps(),
             "seed": seed,
             "sampler_name": sampler or await self.config.guild(guild).sampler(),
+            "sd_model_checkpoint": checkpoint or await self.config.guild(guild).checkpoint(),
+            "width": width or await self.config.guild(guild).width(),
+            "height": height or await self.config.guild(guild).height(),
         }
+        
+        if self.config.guild(guild).adetailer():
+            payload["alwayson_scripts"] = ADETAILER_ARGS
 
         if not nsfw:
             payload["script_name"] = "CensorScript"
@@ -80,11 +91,13 @@ class Functions(MixinMeta):
 
     async def _get_endpoint(self, guild: discord.Guild):
         endpoint = await self.config.guild(guild).endpoint()
+        auth = await self.config.guild(guild).auth()
         nsfw = await self.config.guild(guild).nsfw()
         if not endpoint:
             endpoint = await self.config.endpoint()
+            auth = await self.config.auth()
             nsfw = await self.config.nsfw() and nsfw
-        return endpoint, nsfw
+        return endpoint, auth, nsfw
 
     async def _contains_blacklisted_word(self, guild: discord.Guild, prompt: str):
         endpoint = await self.config.guild(guild).endpoint()
@@ -100,7 +113,12 @@ class Functions(MixinMeta):
     @retry(wait=wait_random(min=2, max=5), stop=stop_after_attempt(2), reraise=True)
     async def _post_sd_endpoint(self, endpoint, payload):
         url = endpoint + "txt2img"
-        async with self.session.post(url=url, json=payload) as response:
+        auth = None
+        auth_str = await self.config.auth()
+        if auth_str:
+            username, password = auth_str.split(':')
+            auth = aiohttp.BasicAuth(username, password)
+        async with self.session.post(url=url, json=payload, auth=auth) as response:
             if response.status != 200:
                 response.raise_for_status()
             r = await response.json()

--- a/aimage/functions.py
+++ b/aimage/functions.py
@@ -59,8 +59,8 @@ class Functions(MixinMeta):
             "width": width or await self.config.guild(guild).width(),
             "height": height or await self.config.guild(guild).height(),
         }
-        
-        if self.config.guild(guild).adetailer():
+
+        if await self.config.guild(guild).adetailer():
             payload["alwayson_scripts"] = ADETAILER_ARGS
 
         if not nsfw:

--- a/aimage/functions.py
+++ b/aimage/functions.py
@@ -55,7 +55,9 @@ class Functions(MixinMeta):
             "steps": steps or await self.config.guild(guild).sampling_steps(),
             "seed": seed,
             "sampler_name": sampler or await self.config.guild(guild).sampler(),
-            "sd_model_checkpoint": checkpoint or await self.config.guild(guild).checkpoint(),
+            "override_settings": {
+                "sd_model_checkpoint": checkpoint or await self.config.guild(guild).checkpoint(),
+            },
             "width": width or await self.config.guild(guild).width(),
             "height": height or await self.config.guild(guild).height(),
         }

--- a/aimage/settings.py
+++ b/aimage/settings.py
@@ -25,20 +25,15 @@ class Settings(MixinMeta):
         config = await self.config.guild(guild).get_raw()
 
         embed = discord.Embed(title="AImage Config", color=await ctx.embed_color())
-        embed.add_field(name="Endpoint", value=config["endpoint"])
-        embed.add_field(name="NSFW allowed",
-                        value=config["nsfw"], inline=False)
-        embed.add_field(name="Default negative prompt",
-                        value=config["negative_prompt"], inline=False)
-        embed.add_field(name="Default sampler",
-                        value=config["sampler"], inline=False)
+        embed.add_field(name="Endpoint", value=config["endpoint"], inline=False)
+        embed.add_field(name="NSFW allowed", value=config["nsfw"])
+        embed.add_field(name="Default negative prompt", value=config["negative_prompt"])
+        embed.add_field(name="Default checkpoint", value=config["checkpoint"])
+        embed.add_field(name="Default sampler", value=config["sampler"])
         embed.add_field(name="Default cfg", value=config["cfg"])
-        embed.add_field(name="Default sampling_steps",
-                        value=config["sampling_steps"])
-        embed.add_field(name="Default checkpoint",
-                        value=config["checkpoint"])
-        embed.add_field(name="Default size",
-                        value=config["width"]+"x"+config["height"])
+        embed.add_field(name="Default sampling_steps", value=config["sampling_steps"])
+        embed.add_field(name="Default size", value=f"{config['width']}x{config['height']}")
+        embed.add_field(name="Use ADetailer", value=config["adetailer"])
         blacklist = ", ".join(config["words_blacklist"])
         if len(blacklist) > 1024:
             blacklist = blacklist[:1020] + "..."
@@ -54,7 +49,9 @@ class Settings(MixinMeta):
         """
         Set the endpoint URL for AI Image (include `/sdapi/v1/`)
         """
-        if not endpoint.endswith("/"):
+        if not endpoint:
+            endpoint = None
+        elif not endpoint.endswith("/"):
             endpoint += "/"
         await self.config.guild(ctx.guild).endpoint.set(endpoint)
         await ctx.tick()
@@ -101,7 +98,7 @@ class Settings(MixinMeta):
         await ctx.tick()
 
     @aimage.command(name="sampler")
-    async def sampler(self, ctx: commands.Context, sampler: str):
+    async def sampler(self, ctx: commands.Context, *, sampler: str):
         """
         Set the default sampler
         """
@@ -140,7 +137,7 @@ class Settings(MixinMeta):
         await ctx.tick()
 
     @aimage.command(name="checkpoint")
-    async def checkpoint(self, ctx: commands.Context, checkpoint: str):
+    async def checkpoint(self, ctx: commands.Context, *, checkpoint: str):
         """
         Set the default checkpoint used for generating images.
         """
@@ -148,7 +145,7 @@ class Settings(MixinMeta):
         await ctx.tick()
 
     @aimage.command(name="auth")
-    async def auth(self, ctx: commands.Context, auth: str):
+    async def auth(self, ctx: commands.Context, *, auth: str):
         """
         Set the API auth username:password in that format.
         """
@@ -160,12 +157,12 @@ class Settings(MixinMeta):
         await ctx.send("✅ Auth set.")
 
     @aimage.command(name="adetailer")
-    async def height(self, ctx: commands.Context):
+    async def adetailer(self, ctx: commands.Context):
         """
         Whether to use face adetailer on generated pictures
         """
-        new = not await self.config.adetailer()
-        await self.config.adetailer.set(new)
+        new = not await self.config.guild(ctx.guild).adetailer()
+        await self.config.guild(ctx.guild).adetailer.set(new)
         await ctx.reply(f"Adetailer set to {new}")
 
     @aimage.group(name="blacklist")

--- a/aimage/settings.py
+++ b/aimage/settings.py
@@ -35,6 +35,10 @@ class Settings(MixinMeta):
         embed.add_field(name="Default cfg", value=config["cfg"])
         embed.add_field(name="Default sampling_steps",
                         value=config["sampling_steps"])
+        embed.add_field(name="Default checkpoint",
+                        value=config["checkpoint"])
+        embed.add_field(name="Default size",
+                        value=config["width"]+"x"+config["height"])
         blacklist = ", ".join(config["words_blacklist"])
         if len(blacklist) > 1024:
             blacklist = blacklist[:1020] + "..."
@@ -114,6 +118,55 @@ class Settings(MixinMeta):
 
         await self.config.guild(ctx.guild).sampler.set(sampler)
         await ctx.tick()
+
+    @aimage.command(name="width")
+    async def width(self, ctx: commands.Context, width: int):
+        """
+        Set the default width
+        """
+        if width < 256 or width > 768:
+            return await ctx.send("Value must range between 256 and 768.")
+        await self.config.guild(ctx.guild).width.set(width)
+        await ctx.tick()
+
+    @aimage.command(name="height")
+    async def height(self, ctx: commands.Context, height: int):
+        """
+        Set the default height
+        """
+        if height < 256 or height > 768:
+            return await ctx.send("Value must range between 256 and 768.")
+        await self.config.guild(ctx.guild).height.set(height)
+        await ctx.tick()
+
+    @aimage.command(name="checkpoint")
+    async def checkpoint(self, ctx: commands.Context, checkpoint: str):
+        """
+        Set the default checkpoint used for generating images.
+        """
+        await self.config.guild(ctx.guild).checkpoint.set(checkpoint)
+        await ctx.tick()
+
+    @aimage.command(name="auth")
+    async def auth(self, ctx: commands.Context, auth: str):
+        """
+        Set the API auth username:password in that format.
+        """
+        try:
+            await ctx.message.delete()
+        except:
+            pass
+        await self.config.guild(ctx.guild).auth.set(auth)
+        await ctx.send("✅ Auth set.")
+
+    @aimage.command(name="adetailer")
+    async def height(self, ctx: commands.Context):
+        """
+        Whether to use face adetailer on generated pictures
+        """
+        new = not await self.config.adetailer()
+        await self.config.adetailer.set(new)
+        await ctx.reply(f"Adetailer set to {new}")
 
     @aimage.group(name="blacklist")
     async def blacklist(self, _: commands.Context):
@@ -230,6 +283,20 @@ class Settings(MixinMeta):
         """
         await self.config.endpoint.set(endpoint)
         await ctx.tick()
+
+    @aimageowner.command(name="auth")
+    async def auth(self, ctx: commands.Context, auth: str):
+        """
+        Set the API auth username:password in that format.
+
+        Will be used if no guild endpoint is set
+        """
+        try:
+            await ctx.message.delete()
+        except:
+            pass
+        await self.config.auth.set(auth)
+        await ctx.send("✅ Auth set.")
 
     @aimageowner.command(name="nsfw")
     async def nsfw_owner(self, ctx: commands.Context):

--- a/aimage/settings.py
+++ b/aimage/settings.py
@@ -68,7 +68,7 @@ class Settings(MixinMeta):
             data = await self._fetch_data(ctx.guild, "scripts") or {}
             await ctx.message.remove_reaction("🔄", ctx.me)
             if "censorscript" not in data.get("txt2img", []):
-                return await ctx.send(":warning: Compatible censor script is not installed in A1111, install [this.](https://github.com/IOMisaka/sdapi-scripts)")
+                return await ctx.send(":warning: Compatible censor script is not installed in A1111, install [this.](<https://github.com/IOMisaka/sdapi-scripts>)")
 
         await self.config.guild(ctx.guild).nsfw.set(not nsfw)
         await ctx.send(f"NSFW filtering is now {'`disabled`' if not nsfw else '`enabled`'}")
@@ -162,8 +162,15 @@ class Settings(MixinMeta):
         Whether to use face adetailer on generated pictures
         """
         new = not await self.config.guild(ctx.guild).adetailer()
+        if new:
+            await ctx.message.add_reaction("🔄")
+            data = await self._fetch_data(ctx.guild, "scripts") or {}
+            await ctx.message.remove_reaction("🔄", ctx.me)
+            if "adetailer" not in data.get("txt2img", []):
+                return await ctx.send(":warning: The adetailer script is not installed in A1111, install [this.](<https://github.com/Bing-su/adetailer>)")
+
         await self.config.guild(ctx.guild).adetailer.set(new)
-        await ctx.reply(f"Adetailer set to {new}")
+        await ctx.send(f"adetailer is now {'`disabled`' if not new else '`enabled`'}")
 
     @aimage.group(name="blacklist")
     async def blacklist(self, _: commands.Context):

--- a/aimage/settings.py
+++ b/aimage/settings.py
@@ -289,7 +289,7 @@ class Settings(MixinMeta):
         await ctx.tick()
 
     @aimageowner.command(name="auth")
-    async def auth(self, ctx: commands.Context, auth: str):
+    async def auth_owner(self, ctx: commands.Context, auth: str):
         """
         Set the API auth username:password in that format.
 
@@ -312,7 +312,8 @@ class Settings(MixinMeta):
         if nsfw:
             await ctx.message.add_reaction("🔄")
             endpoint = await self.config.endpoint()
-            async with self.session.get(endpoint + "scripts") as res:
+            auth_str = await self.config.auth()
+            async with self.session.get(endpoint + "scripts", auth=self.get_auth(auth_str)) as res:
                 if res.status != 200:
                     await ctx.message.remove_reaction("🔄", ctx.me)
                     return await ctx.send(":warning: Couldn't request Stable Diffusion endpoint!")


### PR DESCRIPTION
- width and height are bounded to 256 and 768
- checkpoint has no autocomplete like loras, as I don't know how those are handled exactly
- adetailer depends on the extension of the  same name, it greatly improves quality of faces when enabled at the cost of a few seconds
- auth lets you add `--api-auth username:password` to your webui launch settings for security reasons