### PR TITLE
Implement aihorde as a fallback for image generation

### DIFF
--- a/aimage/aimage.py
+++ b/aimage/aimage.py
@@ -33,7 +33,8 @@ class AImage(Settings,
             "endpoint": None,
             "auth": None,
             "nsfw": True,
-            "words_blacklist": DEFAULT_BADWORDS_BLACKLIST
+            "words_blacklist": DEFAULT_BADWORDS_BLACKLIST,
+            "aihorde": True,
         }
 
         default_guild = {
@@ -49,6 +50,7 @@ class AImage(Settings,
             "width": 512,
             "height": 512,
             "auth": None,
+            "aihorde_anime": False,
         }
 
         self.session = aiohttp.ClientSession()
@@ -125,7 +127,8 @@ class AImage(Settings,
             for choice in choices[:24]
         ]
 
-    def filter_list(self, options: list[str], filter: str):
+    @staticmethod
+    def filter_list(options: list[str], filter: str):
         results = []
         available = list(options)
 

--- a/aimage/settings.py
+++ b/aimage/settings.py
@@ -172,6 +172,16 @@ class Settings(MixinMeta):
         await self.config.guild(ctx.guild).adetailer.set(new)
         await ctx.send(f"adetailer is now {'`disabled`' if not new else '`enabled`'}")
 
+    @aimage.command(name="aihorde_mode")
+    async def aihorde_mode(self, ctx: commands.Context):
+        """
+        Whether the aihorde fallback, if enabled, should use a generalist model or an anime model.
+        """
+        new = not await self.config.guild(ctx.guild).aihorde_anime()
+        await self.config.guild(ctx.guild).aihorde_anime.set(new)
+        await ctx.send(f"aihorde mode is now {'`generalist`' if not new else '`anime`'}")
+
+
     @aimage.group(name="blacklist")
     async def blacklist(self, _: commands.Context):
         """
@@ -324,6 +334,16 @@ class Settings(MixinMeta):
             await ctx.message.remove_reaction("🔄", ctx.me)
         await self.config.nsfw.set(not nsfw)
         await ctx.send(f"NSFW filtering is now {'`disabled`' if not nsfw else '`enabled`'}")
+
+    @aimageowner.command(name="aihorde")
+    async def aihorde_owner(self, ctx: commands.Context):
+        """
+        Whether to use aihorde as a fallback for generations.
+        Set your AI Horde API key with [p]set api ai-horde api_key,API_KEY
+        """
+        new = not await self.config.aihorde()
+        await self.config.aihorde.set(new)
+        await ctx.send(f"aihorde fallback is now {'`disabled`' if not new else '`enabled`'}")
 
     @aimageowner.group(name="blacklist")
     async def blacklist_owner(self, _: commands.Context):

--- a/aimage/stablehordeapi.py
+++ b/aimage/stablehordeapi.py
@@ -1,0 +1,53 @@
+# https://github.com/F1zzTao/StableHordeAPI.py/blob/main/stablehorde_api/client.py
+import aiohttp
+import json
+from typing import Optional
+
+class StableHordeAPI:
+    def __init__(
+        self, api_key: Optional[str] = None,
+        api: Optional[str] = 'https://stablehorde.net/api/v2',
+        session: Optional[aiohttp.ClientSession] = None,
+    ):
+        if session is None:
+            self._session = aiohttp.ClientSession()
+        else:
+            self._session = session
+        self.api_key: str = api_key
+        self.api: str = api
+
+    async def _request(self, url: str, method: str = 'GET', json=None, headers=None) -> aiohttp.ClientResponse:
+        """Request an url using choiced method"""
+        response = await self._session.request(method, url, json=json, headers=headers)
+        return response
+
+    async def txt2img_request(self, payload: dict) -> dict:
+        """Create an asynchronous request to generate images"""
+        response = await self._request(
+            self.api+'/generate/async', "POST", payload, {'apikey': self.api_key}
+        )
+        return json.loads(await response.content.read())
+
+    async def generate_check(self, uuid: str) -> dict:
+        """Check the status of generation without consuming bandwidth"""
+        response = await self._request(
+            self.api+f'/generate/check/{uuid}'
+        )
+        if response.status == 404:
+            raise ValueError("You entered an UUID that is not found")
+
+        return json.loads(await response.content.read())
+
+    async def generate_status(self, uuid: str) -> dict:
+        """
+        Same as `generate_check`, but will also include all already
+        generated images in a base64 encoded .webp files (if r2 not set).
+        You should not request this often. It's limited to 1 request per minute
+        """
+        response = await self._request(
+            self.api+f'/generate/status/{uuid}'
+        )
+        if response.status == 404:
+            raise ValueError("You entered an UUID that is not found")
+
+        return json.loads(await response.content.read())


### PR DESCRIPTION
Merry Christmas.

The basics work. Whenever it fails to grab from an endpoint, if the setting is enabled bot-wide it will request an image from aihorde. If possible, it will use the api key stored in the bot. Each guild can configure whether it wants general images or anime images. The images aren't great, but it's free.

![image](https://github.com/zhaobenny/bz-cogs/assets/33796679/508f49f6-9978-42fd-95e4-53d630ee655e)
