### PR TITLE
Add hires upscale, add variation parameter

### DIFF
--- a/aimage/abc.py
+++ b/aimage/abc.py
@@ -2,6 +2,7 @@ from abc import ABC
 
 import discord
 from aiohttp import ClientSession
+from collections import defaultdict
 from redbot.core import Config, commands
 from redbot.core.bot import Red
 
@@ -14,6 +15,7 @@ class MixinMeta(ABC):
     bot: Red
     config: Config
     session: ClientSession
+    autocomplete_cache: defaultdict
 
     def __init__(self, *args):
         pass

--- a/aimage/aimage.py
+++ b/aimage/aimage.py
@@ -129,7 +129,7 @@ class AImage(Settings,
         steps="How many sampling steps, 20-30 is common.",
         seed="Random number that generates the image, -1 for random.",
         variation="Finetunes details within the same seed, 0.05 is common.",
-        variation_seed="The subseed guides the variation, -1 for random.",
+        variation_seed="This subseed guides the variation, -1 for random.",
         checkpoint="The main AI model used to generate the image.",
         vae="The VAE converts the final details of the image.",
         lora="Shortcut to insert a LoRA into the prompt.",
@@ -167,7 +167,7 @@ class AImage(Settings,
         if not await self._can_run_command(ctx, "imagine"):
             return await interaction.response.send_message("You do not have permission to do this.", ephemeral=True)
 
-        await self.generate_image(ctx,
+        await self.generate_image(interaction,
                                   prompt=prompt, negative_prompt=negative_prompt,
                                   width=width, height=height, cfg=cfg, sampler=sampler, steps=steps,
                                   seed=seed, subseed=variation_seed, subseed_strength=variation,

--- a/aimage/constants.py
+++ b/aimage/constants.py
@@ -1,6 +1,6 @@
 import re
 
-DEFAULT_NEGATIVE_PROMPT = "(worst quality, bad quality:1.4)"
+DEFAULT_NEGATIVE_PROMPT = "(worst quality, low quality:1.4)"
 
 # taken from https://www.greataiprompts.com/imageprompt/list-of-banned-words-in-midjourney/
 DEFAULT_BADWORDS_BLACKLIST = ["blood", "bloodbath", "crucifixion", "bloody", "flesh", "bruises", "car crash", "corpse", "crucified", "cutting", "decapitate", "infested", "gruesome", "kill", "infected", "sadist", "slaughter", "teratoma", "tryphophobia", "wound", "cronenberg", "khorne", "cannibal", "cannibalism", "visceral", "guts", "bloodshot", "gory", "killing", "surgery", "vivisection", "massacre", "hemoglobin", "suicide", "female body parts", "ahegao", "pinup", "ballgag", "playboy", "bimbo", "pleasure", "bodily fluids", "pleasures", "boudoir", "rule34", "brothel", "seducing", "dominatrix", "seductive", "erotic seductive", "fuck", "sensual", "hardcore", "sexy", "hentai", "shag", "horny", "shibari", "incest", "smut", "jav", "succubus", "jerk off king at pic", "thot", "kinbaku", "transparent", "legs spread", "twerk", "making love", "voluptuous", "naughty", "wincest", "orgy", "sultry",

--- a/aimage/constants.py
+++ b/aimage/constants.py
@@ -1,6 +1,6 @@
 import re
 
-DEFAULT_NEGATIVE_PROMPT = "ugly, tiling, poorly drawn hands, poorly drawn feet, poorly drawn face, out of frame, extra limbs, disfigured, deformed, body out of frame, bad anatomy, watermark, signature, cut off, low contrast, underexposed, overexposed, bad art, beginner, amateur, distorted face"
+DEFAULT_NEGATIVE_PROMPT = "(worst quality, bad quality:1.4)"
 
 # taken from https://www.greataiprompts.com/imageprompt/list-of-banned-words-in-midjourney/
 DEFAULT_BADWORDS_BLACKLIST = ["blood", "bloodbath", "crucifixion", "bloody", "flesh", "bruises", "car crash", "corpse", "crucified", "cutting", "decapitate", "infested", "gruesome", "kill", "infected", "sadist", "slaughter", "teratoma", "tryphophobia", "wound", "cronenberg", "khorne", "cannibal", "cannibalism", "visceral", "guts", "bloodshot", "gory", "killing", "surgery", "vivisection", "massacre", "hemoglobin", "suicide", "female body parts", "ahegao", "pinup", "ballgag", "playboy", "bimbo", "pleasure", "bodily fluids", "pleasures", "boudoir", "rule34", "brothel", "seducing", "dominatrix", "seductive", "erotic seductive", "fuck", "sensual", "hardcore", "sexy", "hentai", "shag", "horny", "shibari", "incest", "smut", "jav", "succubus", "jerk off king at pic", "thot", "kinbaku", "transparent", "legs spread", "twerk", "making love", "voluptuous", "naughty", "wincest", "orgy", "sultry",

--- a/aimage/constants.py
+++ b/aimage/constants.py
@@ -38,7 +38,12 @@ AUTO_COMPLETE_SAMPLERS = [
     "Restart",
     "DDIM",
     "PLMS",
-    "UniPC"
+    "UniPC",
+]
+
+AUTO_COMPLETE_UPSCALERS = [
+    "Latent",
+    "Latent (nearest-exact)",
 ]
 
 ADETAILER_ARGS = {

--- a/aimage/functions.py
+++ b/aimage/functions.py
@@ -24,7 +24,7 @@ def round_to_nearest(x, base):
 
 class Functions(MixinMeta):
     async def generate_image(self,
-                             context: commands.Context,
+                             context: Union[commands.Context, discord.Interaction],
                              payload: dict = None,
                              prompt: str = "",
                              negative_prompt: str = None,
@@ -40,8 +40,8 @@ class Functions(MixinMeta):
                              vae: str = None,
                              lora: str = None):
 
-        if context.interaction:
-            await context.interaction.response.defer(thinking=True)
+        if isinstance(context, discord.Interaction):
+            await context.response.defer(thinking=True)
         else:
             await context.message.add_reaction("⏳")
 
@@ -98,8 +98,7 @@ class Functions(MixinMeta):
                     logger.exception(f"Failed request to Stable Diffusion endpoint in server {guild.id}")
                     return await self.send_response(context, content=":warning: Something went wrong!", ephemeral=True)
 
-        user = context.user if isinstance(
-            context, discord.Interaction) else context.author
+        user = context.user if isinstance(context, discord.Interaction) else context.author
         if is_nsfw:
             return await self.send_response(context, content=f"🔞 {user.mention} generated a possible NSFW image with prompt: `{prompt}`", allowed_mentions=discord.AllowedMentions.none())
 
@@ -114,9 +113,9 @@ class Functions(MixinMeta):
                 imagescanner.image_cache[msg.id] = ({1: info_string}, {1: image_data})
                 await msg.add_reaction("🔎")
 
-    async def send_response(self, context: commands.Context, **kwargs) -> discord.Message:
-        if context.interaction:
-            return await context.interaction.followup.send(**kwargs)
+    async def send_response(self, context: Union[commands.Context, discord.Interaction], **kwargs) -> discord.Message:
+        if isinstance(context, discord.Interaction):
+            return await context.followup.send(**kwargs)
         else:
             try:
                 await context.message.remove_reaction("⏳", self.bot.user)

--- a/aimage/functions.py
+++ b/aimage/functions.py
@@ -24,22 +24,24 @@ def round_to_nearest(x, base):
 
 class Functions(MixinMeta):
     async def generate_image(self,
-                             context: Union[commands.Context, discord.Interaction],
-                             prompt: str,
-                             lora: str = None,
-                             cfg: int = None,
+                             context: commands.Context,
+                             payload: dict = None,
+                             prompt: str = "",
                              negative_prompt: str = None,
-                             steps: int = None,
-                             seed: int = -1,
-                             sampler: str = None,
                              width: int = None,
                              height: int = None,
+                             cfg: int = None,
+                             sampler: str = None,
+                             steps: int = None,
+                             seed: int = -1,
+                             subseed: int = -1,
+                             subseed_strength: float = 0,
                              checkpoint: str = None,
                              vae: str = None,
-                             payload: dict = None):
+                             lora: str = None):
 
-        if isinstance(context, discord.Interaction):
-            await context.response.defer(thinking=True)
+        if context.interaction:
+            await context.interaction.response.defer(thinking=True)
         else:
             await context.message.add_reaction("⏳")
 
@@ -47,13 +49,13 @@ class Functions(MixinMeta):
 
         endpoint, auth_str, nsfw = await self._get_endpoint(guild)
         if not endpoint:
-            return await self.sent_response(context, content=":warning: Endpoint not yet set for this server!")
+            return await self.send_response(context, content=":warning: Endpoint not yet set for this server!")
 
         if await self._contains_blacklisted_word(guild, prompt):
-            return self.sent_response(context, content=":warning: Prompt contains blacklisted words!")
+            return self.send_response(context, content=":warning: Prompt contains blacklisted words!")
 
         if lora:
-            prompt = f"{lora} {prompt}"
+            prompt += lora  # loras are parsed out of the prompt beforehand
 
         payload = payload or {
             "prompt": prompt,
@@ -61,6 +63,8 @@ class Functions(MixinMeta):
             "negative_prompt": negative_prompt or await self.config.guild(guild).negative_prompt(),
             "steps": steps or await self.config.guild(guild).sampling_steps(),
             "seed": seed,
+            "subseed": subseed,
+            "subseed_strength": subseed_strength,
             "sampler_name": sampler or await self.config.guild(guild).sampler(),
             "override_settings": {
                 "sd_model_checkpoint": checkpoint or await self.config.guild(guild).checkpoint(),
@@ -82,22 +86,26 @@ class Functions(MixinMeta):
             image_extension = "png"
         except Exception as error:
             if await self.config.aihorde():
-                image_data, info_string, is_nsfw = await self._request_aihorde(context, nsfw, payload)
+                aihorde_result = await self._request_aihorde(context, nsfw, payload)
+                if isinstance(aihorde_result, discord.Message):
+                    return
+                image_data, info_string, is_nsfw = aihorde_result
                 image_extension = ".webp"
             else:
                 if isinstance(error, aiohttp.ClientConnectorError):
-                    return await self.sent_response(context, content=":warning: Timed out! Server is offline.", ephemeral=True)
+                    return await self.send_response(context, content=":warning: Timed out! Server is offline.", ephemeral=True)
                 else:
                     logger.exception(f"Failed request to Stable Diffusion endpoint in server {guild.id}")
-                    return await self.sent_response(context, content=":warning: Something went wrong!", ephemeral=True)
+                    return await self.send_response(context, content=":warning: Something went wrong!", ephemeral=True)
 
         user = context.user if isinstance(
             context, discord.Interaction) else context.author
         if is_nsfw:
-            return await self.sent_response(context, content=f"🔞 {user.mention} generated a possible NSFW image with prompt: `{prompt}`", allowed_mentions=discord.AllowedMentions.none())
+            return await self.send_response(context, content=f"🔞 {user.mention} generated a possible NSFW image with prompt: `{prompt}`", allowed_mentions=discord.AllowedMentions.none())
 
-        view = ImageActions(cog=self, image_info=info_string, payload=payload, author=user, channel=context.channel)
-        msg = await self.sent_response(context, file=discord.File(io.BytesIO(image_data), filename=f"image.{image_extension}"), view=view)
+        file = discord.File(io.BytesIO(image_data), filename=f"image.{image_extension}")
+        view = ImageActions(self, info_string, payload, user, context.channel)
+        msg = await self.send_response(context, file=file, view=view)
         asyncio.create_task(self.delete_button_after(msg))
 
         imagescanner = self.bot.get_cog("ImageScanner")
@@ -106,14 +114,15 @@ class Functions(MixinMeta):
                 imagescanner.image_cache[msg.id] = ({1: info_string}, {1: image_data})
                 await msg.add_reaction("🔎")
 
-    async def sent_response(self, context: Union[commands.Context, discord.Interaction], **kwargs):
-        if isinstance(context, discord.Interaction):
-            return await context.followup.send(**kwargs)
-        try:
-            await context.message.remove_reaction("⏳", self.bot.user)
-        except:
-            pass
-        return await context.send(**kwargs)
+    async def send_response(self, context: commands.Context, **kwargs) -> discord.Message:
+        if context.interaction:
+            return await context.interaction.followup.send(**kwargs)
+        else:
+            try:
+                await context.message.remove_reaction("⏳", self.bot.user)
+            except:
+                pass
+            return await context.send(**kwargs)
 
     async def _get_endpoint(self, guild: discord.Guild):
         endpoint: str = await self.config.guild(guild).endpoint()
@@ -150,21 +159,19 @@ class Functions(MixinMeta):
             info = json.loads(r["info"])
             info_string = info.get("infotexts")[0]
             try:
-                is_nsfw = info.get("extra_generation_params",
-                                   {}).get("nsfw", [])[0]
-                if is_nsfw:
-                    # try to save you from cold boot attack
-                    del r["images"]
-                    r["images"] = []
-                    del image_data
-                    image_data = ""
+                is_nsfw = info.get("extra_generation_params", {}).get("nsfw", [])[0]
             except IndexError:
                 is_nsfw = False
+            if is_nsfw:
+                # try to save you from cold boot attack
+                del r["images"]
+                r["images"] = []
+                del image_data
+                image_data = ""
 
             if logger.isEnabledFor(logging.DEBUG):
                 del r["images"]
-                logger.debug(
-                    f"Requested with parameters: {json.dumps(r, indent=4)}")
+                logger.debug(f"Requested with parameters: {json.dumps(r, indent=4)}")
 
         return image_data, info_string, is_nsfw
 
@@ -188,7 +195,7 @@ class Functions(MixinMeta):
         response = await client.txt2img_request(horde_payload)
         if response.get("errors", None):
             logger.error(response)
-            return await self.sent_response(context, content=":warning: Something went wrong with AI Horde!", ephemeral=True)
+            return await self.send_response(context, content=":warning: Something went wrong with AI Horde!", ephemeral=True)
         img_uuid = response["id"]
         done = False
         elapsed = 0
@@ -200,7 +207,7 @@ class Functions(MixinMeta):
         generate_status = await client.generate_status(img_uuid)
         if not generate_status["done"]:
             logger.error(f"Failed request to AI Horde in server {context.guild.id}")
-            return await self.sent_response(context, content=":warning: AI Horde timed out!", ephemeral=True)
+            return await self.send_response(context, content=":warning: AI Horde timed out!", ephemeral=True)
         res = generate_status["generations"][0]
         image_url = res["img"]
         async with self.session.get(image_url) as response:
@@ -214,7 +221,6 @@ class Functions(MixinMeta):
         try:
             endpoint, auth_str, _ = await self._get_endpoint(guild)
             url = endpoint + endpoint_suffix
-
             async with self.session.get(url, auth=self.get_auth(auth_str)) as response:
                 response.raise_for_status()
                 res = await response.json()

--- a/aimage/views.py
+++ b/aimage/views.py
@@ -1,29 +1,45 @@
 import asyncio
 import io
-from collections import OrderedDict
+from collections import OrderedDict, defaultdict
 
 import discord
 from redbot.core.bot import Red
-from typing import Optional
+from typing import Optional, Coroutine
 
 from aimage.abc import MixinMeta
 from aimage.constants import (PARAM_GROUP_REGEX, PARAM_REGEX, PARAMS_BLACKLIST,
-                              VIEW_TIMEOUT)
+                              VIEW_TIMEOUT, AUTO_COMPLETE_UPSCALERS)
 from aimage.functions import delete_button_after
 
 
 class ImageActions(discord.ui.View):
     def __init__(self, cog: MixinMeta, image_info: str, payload: dict, author: discord.Member, channel: discord.TextChannel):
+        super().__init__(timeout=VIEW_TIMEOUT)
         self.info_string = image_info
         self.payload = payload
         self.bot: Red = cog.bot
         self.generate_image = cog.generate_image
+        self.cache = cog.autocomplete_cache
         self.og_user = author
         self.channel = channel
-        super().__init__(timeout=VIEW_TIMEOUT)
 
-    @discord.ui.button(emoji='🔎')
-    async def get_caption(self, interaction: discord.Interaction, _: discord.ui.Button):
+        self.button_caption = discord.ui.Button(emoji='🔎')
+        self.button_caption.callback = self.get_caption
+        self.button_regenerate = discord.ui.Button(emoji='🔄')
+        self.button_regenerate.callback = self.regenerate_image
+        self.button_upscale = discord.ui.Button(emoji='⬆')
+        self.button_upscale.callback = self.upscale_image
+        self.button_delete = discord.ui.Button(emoji='🗑️')
+        self.button_delete.callback = self.delete_image
+
+        self.add_item(self.button_caption)
+        if not payload.get("enable_hr", False):
+            self.add_item(self.button_regenerate)
+            if payload["width"]*payload["height"] <= 768*768:
+                self.add_item(self.button_upscale)
+        self.add_item(self.button_delete)
+
+    async def get_caption(self, interaction: discord.Interaction):
         embed = await self._get_params_embed()
         if embed:
             view = ParamsView(self.info_string, interaction)
@@ -33,28 +49,32 @@ class ImageActions(discord.ui.View):
         else:
             await interaction.response.send_message(f'Parameters for this image:\n```yaml\n{self.info_string}```')
 
-    @discord.ui.button(emoji='🔄')
-    async def regenerate_image(self, interaction: discord.Interaction, button: discord.ui.Button):
-        params = self._get_params_dict()
+    async def regenerate_image(self, interaction: discord.Interaction):
+        params = self.get_params_dict()
         if params and float(params.get("Variation seed strength", 0)) > 0:
             self.payload["seed"] = int(params["Seed"])
             self.payload["subseed"] = -1
         else:
             self.payload["seed"] = -1
-        button.disabled = True
+        self.button_regenerate.disabled = True
         await interaction.message.edit(view=self)
         await self.generate_image(interaction, payload=self.payload)
-        button.disabled = False
+        self.button_regenerate.disabled = False
         if not self.is_finished():
-            await interaction.message.edit(view=self)
+            try:
+                await interaction.message.edit(view=self)
+            except:
+                pass
 
-    @discord.ui.button(emoji='🗑️')
-    async def delete_image(self, interaction: discord.Interaction, button: discord.ui.Button):
+    async def upscale_image(self, interaction: discord.Interaction):
+        view = HiresView(self, self.button_upscale, interaction, self.payload, self.cache, self.generate_image)
+        await interaction.response.send_message(view=view, ephemeral=True)
 
+    async def delete_image(self, interaction: discord.Interaction):
         if not (await self._check_if_can_delete(interaction)):
             return await interaction.response.send_message(content=":warning: Only the requester and staff can delete this image!", ephemeral=True)
 
-        button.disabled = True
+        self.button_delete.disabled = True
         await interaction.message.delete()
 
         prompt = self.payload["prompt"]
@@ -65,16 +85,7 @@ class ImageActions(discord.ui.View):
 
         self.stop()
 
-    async def _check_if_can_delete(self, interaction: discord.Interaction):
-        is_og_user = interaction.user.id == self.og_user.id
-
-        guild = interaction.guild
-        member = guild.get_member(interaction.user.id)
-        is_staff = await self.bot.is_mod(member) or await self.bot.is_admin(member) or await self.bot.is_owner(member)
-
-        return is_og_user or is_staff
-
-    def _get_params_dict(self) -> Optional[dict]:
+    def get_params_dict(self) -> Optional[dict]:
         if "Steps: " not in self.info_string:
             return None
         output_dict = OrderedDict()
@@ -96,13 +107,22 @@ class ImageActions(discord.ui.View):
         return output_dict
 
     async def _get_params_embed(self) -> Optional[discord.Embed]:
-        params = self._get_params_dict()
+        params = self.get_params_dict()
         if not params:
             return None
         embed = discord.Embed(title="Image Parameters", color=await self.bot.get_embed_color(self.channel))
         for key, value in params.items():
             embed.add_field(name=key, value=value, inline="Prompt" not in key)
         return embed
+
+    async def _check_if_can_delete(self, interaction: discord.Interaction):
+        is_og_user = interaction.user.id == self.og_user.id
+
+        guild = interaction.guild
+        member = guild.get_member(interaction.user.id)
+        is_staff = await self.bot.is_mod(member) or await self.bot.is_admin(member) or await self.bot.is_owner(member)
+
+        return is_og_user or is_staff
 
 
 class ParamsView(discord.ui.View):
@@ -111,18 +131,107 @@ class ParamsView(discord.ui.View):
         self.params = params
         self.src_interaction = interaction
 
-    @discord.ui.button(emoji="🔧", label='View Full', style=discord.ButtonStyle.grey)
-    async def view_full_parameters(self, ctx: discord.Interaction, _: discord.Button):
+    @discord.ui.button(emoji='🔧', label='View Full')
+    async def view_full_parameters(self, interaction: discord.Interaction, _: discord.Button):
         if len(self.params) < 1980:
-            await ctx.response.send_message(f"```yaml\n{self.params}```", ephemeral=True)
+            await interaction.response.send_message(f"```yaml\n{self.params}```", ephemeral=True)
         else:
             with io.StringIO() as f:
                 f.write(self.params)
                 f.seek(0)
-                await ctx.response.send_message(file=discord.File(f, "parameters.yaml"), ephemeral=True)
+                await interaction.response.send_message(file=discord.File(f, "parameters.yaml"), ephemeral=True)
 
         self.stop()
         try:
             await self.src_interaction.edit_original_response(view=None)
         except:
             pass
+
+
+class HiresView(discord.ui.View):
+    def __init__(self,
+                 parent: ImageActions,
+                 button: discord.ui.Button,
+                 interaction: discord.Interaction,
+                 payload: dict,
+                 cache: defaultdict,
+                 generate_image):
+        super().__init__()
+        self.src_view = parent
+        self.src_button = button
+        self.src_interaction = interaction
+        self.payload = payload
+        self.generate_image = generate_image
+        upscalers = (AUTO_COMPLETE_UPSCALERS + cache[interaction.guild.id]["upscalers"])[:25]
+        self.upscaler = upscalers[0]
+        self.scale = 1.5
+        self.denoising = 0.5
+        self.add_item(UpscalerSelect(self, upscalers))
+        self.add_item(ScaleSelect(self))
+        self.add_item(DenoisingSelect(self))
+
+    @discord.ui.button(emoji='⬆', label='Upscale', style=discord.ButtonStyle.blurple, row=3)
+    async def upscale(self, interaction: discord.Interaction, button: discord.Button):
+        self.payload["enable_hr"] = True
+        self.payload["hr_upscaler"] = self.upscaler
+        self.payload["hr_scale"] = self.scale
+        self.payload["denoising_strength"] = self.denoising
+        self.payload["hr_second_pass_steps"] = self.payload["steps"] // 2
+        self.payload["hr_prompt"] = self.payload["prompt"]
+        self.payload["hr_negative_prompt"] = self.payload["negative_prompt"]
+        self.payload["hr_resize_x"] = 0
+        self.payload["hr_resize_y"] = 0
+        params = self.src_view.get_params_dict()
+        self.payload["seed"] = int(params["Seed"])
+        self.payload["subseed"] = int(params.get("Variation seed", -1))
+
+        button.disabled = True
+        self.src_button.disabled = True
+        await self.src_interaction.message.edit(view=self.src_view)
+        await self.src_interaction.edit_original_response(view=self)
+        await self.generate_image(interaction, payload=self.payload)
+
+
+class UpscalerSelect(discord.ui.Select):
+    def __init__(self, parent: HiresView, upscalers: list[str]):
+        self.parent = parent
+        super().__init__(
+            options=[discord.SelectOption(label=name, default=i == 1)
+                     for i, name in enumerate(upscalers)]
+        )
+
+    async def callback(self, interaction: discord.Interaction):
+        self.parent.upscaler = self.values[0]
+        for option in self.options:
+            option.default = option.value == self.values[0]
+        await interaction.response.edit_message(view=self.parent)
+
+
+class ScaleSelect(discord.ui.Select):
+    def __init__(self, parent: HiresView):
+        self.parent = parent
+        super().__init__(
+            options=[discord.SelectOption(label=f"x{num:.2f}", value=str(num), default=num == 1.5)
+                     for num in (1.25, 1.5, 1.75, 2)]
+        )
+
+    async def callback(self, interaction: discord.Interaction):
+        self.parent.scale = float(self.values[0])
+        for option in self.options:
+            option.default = option.value == self.values[0]
+        await interaction.response.edit_message(view=self.parent)
+
+
+class DenoisingSelect(discord.ui.Select):
+    def __init__(self, parent: HiresView):
+        self.parent = parent
+        super().__init__(
+            options=[discord.SelectOption(label=f"Denoising: {num/100}", value=str(num/100), default=num == 50)
+                     for num in range(5, 100, 5)]
+        )
+
+    async def callback(self, interaction: discord.Interaction):
+        self.parent.denoising = float(self.values[0])
+        for option in self.options:
+            option.default = option.value == self.values[0]
+        await interaction.response.edit_message(view=self.parent)

--- a/aimage/views.py
+++ b/aimage/views.py
@@ -212,7 +212,7 @@ class ScaleSelect(discord.ui.Select):
         self.parent = parent
         super().__init__(
             options=[discord.SelectOption(label=f"x{num:.2f}", value=str(num), default=num == 1.5)
-                     for num in (1.25, 1.5, 1.75, 2)]
+                     for num in (1.00, 1.25, 1.5, 1.75, 2)]
         )
 
     async def callback(self, interaction: discord.Interaction):


### PR DESCRIPTION
- Implemented hires fix (upscale), in the form of a button that opens an ephemeral interactive message, letting you select some settings before upscaling the image. The image is made from scratch with the same parameters, but this time with "hires fix" mode at the end, which increases its size and quality. This button is not present with images larger than 768x768 pixels.
- The new variation parameter lets you finetune details within the same seed. Regenerating an image that has a variation value above 0 will use the same seed but change the subseed instead.
- The code was slightly cleaned up, with a couple extra checks for stability.
- The slash command parameter descriptions were again tweaked to be more informative.
- The default negative prompt was changed to a more modern and minimalist approach. It should be very effective on recent anime checkpoints (last 6 months) among others.