### PR TITLE
include discord system messages

### DIFF
--- a/aiuser/messages_list/converter/helpers.py
+++ b/aiuser/messages_list/converter/helpers.py
@@ -8,6 +8,8 @@ logger = logging.getLogger("red.bz_cogs.aiuser")
 
 
 def format_text_content(message: Message):
+    if message.type == MessageType.new_member:
+        return f'User "{message.author.display_name}" has joined the server. Their Discord ID is {message.author.id}'
     if message.type != MessageType.default:
         return message.system_content
     if not message.content or message.content == "" or message.content.isspace():

--- a/aiuser/messages_list/converter/helpers.py
+++ b/aiuser/messages_list/converter/helpers.py
@@ -1,6 +1,6 @@
 import logging
 
-from discord import Message
+from discord import Message, MessageType
 
 from aiuser.common.constants import URL_PATTERN
 
@@ -8,6 +8,8 @@ logger = logging.getLogger("red.bz_cogs.aiuser")
 
 
 def format_text_content(message: Message):
+    if message.type != MessageType.default:
+        return message.system_content
     if not message.content or message.content == "" or message.content.isspace():
         return None
     content = mention_to_text(message)

--- a/aiuser/response/chat/response.py
+++ b/aiuser/response/chat/response.py
@@ -34,17 +34,19 @@ class ChatResponse():
         if not self.response:
             return False
 
+        allowed_mentions = AllowedMentions(everyone=False, roles=False, users=[message.author])
+
         if len(self.response) >= 2000:
-            chunks = [self.response[i:i+2000]
+            chunks = [self.response[i:i + 2000]
                       for i in range(0, len(self.response), 2000)]
             for chunk in chunks:
-                await self.ctx.send(chunk)
+                await self.ctx.send(chunk, allowed_mentions=allowed_mentions)
         elif self.can_reply and await self.is_reply():
-            await message.reply(self.response, mention_author=False, allowed_mentions=AllowedMentions.none())
+            await message.reply(self.response, mention_author=False, allowed_mentions=allowed_mentions)
         elif self.ctx.interaction:
-            await self.ctx.interaction.followup.send(self.response, allowed_mentions=AllowedMentions.none())
+            await self.ctx.interaction.followup.send(self.response, allowed_mentions=allowed_mentions)
         else:
-            await self.ctx.send(self.response, allowed_mentions=AllowedMentions.none())
+            await self.ctx.send(self.response, allowed_mentions=allowed_mentions)
         return True
 
     async def remove_patterns_from_response(self) -> str:


### PR DESCRIPTION
This change lets the bot read "system" chat messages, such as member join events.

For this aforementioned purpose, 2 very specific changes have been made:

1. The display_name and id of the user who joined will be shown to the bot.

2. It gives the bot implicit permission to ping the author of the message that triggered it. This would only come into play if the bot knew the id of said user, so normally this doesn't do anything.

These 2 changes in tandem allow the bot to serve as a welcome bot, by pinging a user when it joins and giving a personalized welcome message.

![image](https://github.com/zhaobenny/bz-cogs/assets/33796679/9d3dd195-d022-4e2c-ac02-31cf89370b52)
