### PR TITLE
docs: add Spanish README

### DIFF
--- a/README.es-ES.md
+++ b/README.es-ES.md
@@ -1,0 +1,39 @@
+
+
+<h1 align="center">bz-cogs</h1> 
+<p align="center">
+<a href="https://discord.gg/GwT2yHPqzN"><img src="https://discordapp.com/api/guilds/744802856074346556/embed.png"></a>
+<a href="https://github.com/Cog-Creators/Red-DiscordBot/"><img src="https://img.shields.io/static/v1?label=Red-DiscordBot&message=3.5&color=red&style=flat"></a>
+<a href="https://github.com/Rapptz/discord.py"><img src="https://img.shields.io/static/v1?label=Discord&message=py&color=blue&style=flat&logo=discord"></a>
+<a href="https://makeapullrequest.com"><img src="https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat"></a>
+
+<p align="center">
+Una colección de cogs interesantes/de nicho para Red-Discordbot.
+
+## Instalación
+```
+repo add bz-cogs https://github.com/zhaobenny/bz-cogs
+cog install bz-cogs <cog>
+```
+
+## Cogs
+| Nombre | Descripción
+| --- | --- |
+[aiuser](https://github.com/zhaobenny/bz-cogs/tree/main/aiuser) | Interacciones en Discord ˆumanizadas impulsadas por OpenAI y endpoints compatibles para mensajes (e imágenes).
+[aiemote](https://github.com/zhaobenny/bz-cogs/tree/main/aiemote) | Reacciones en Discord ˆumanizadas impulsadas por OpenAI.
+[aimage](https://github.com/zhaobenny/bz-cogs/tree/main/aimage) | Generación de imágenes con Stable Diffusion A1111 en Discord.
+oneletteronly | Configura los apodos como iniciales para nuevos usuarios.
+
+
+## ¿Soporte / sugerencias?
+Dirígete al [servidor de bz-cogs](https://discord.gg/GwT2yHPqzN).
+
+O etiqueta a *@Define* en el canal [#support_othercogs](https://discord.com/channels/240154543684321280/240212783503900673) del [servidor de soporte de cogs de Red](https://discord.gg/GET4DVk).
+
+## Colaboradores 🎉
+<a href="https://github.com/zhaobenny/bz-cogs/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=zhaobenny/bz-cogs" />
+</a>
+
+## Licencia
+[MIT](https://github.com/zhaobenny/bz-cogs/blob/main/LICENSE)


### PR DESCRIPTION
Adds README.es-ES.md alongside the original documentation.

Generated by `qwen3.6-35b-a3b via local API`.